### PR TITLE
Fix text splitter best_separator initialization

### DIFF
--- a/application/RAG/bot_parts/text_splitter.py
+++ b/application/RAG/bot_parts/text_splitter.py
@@ -24,6 +24,9 @@ def split_text(text, chunk_size=800, overlap_sentences=1, separators=['\n\n', '.
             temp_text = paragraph
             while temp_text:
                 best_split = -1
+                # Initialize best_separator to avoid UnboundLocalError if no
+                # separator is found in the current text chunk
+                best_separator = ""
                 for separator in separators:
                     if separator == "":
                         break


### PR DESCRIPTION
## Summary
- prevent `UnboundLocalError` if no separator is found when splitting text

## Testing
- `python -m py_compile application/RAG/bot_parts/text_splitter.py`

------
https://chatgpt.com/codex/tasks/task_e_686b51b9c6148321b3a2dc273a9d4ff3